### PR TITLE
feat: add s-const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.0.19]
+
+- feat: add `s-const`
+
 # [1.0.18]
 
 - pref: change `sk-page-params` to new type api

--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ This extension is a set of Snippets for Svelte. They are created so that scaffol
 </details>
 
 <details>
+<summary>s-const</summary>
+
+```
+{@const name = value}
+
+```
+
+</details>
+
+<details>
 <summary>s-slot</summary>
 
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-5-snippets",
   "displayName": "Svelte 5 Snippets",
   "description": "svelte5 and svelte-kit snippets for vscode",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "license": "MIT",
   "publisher": "Chanzhaoyu",
   "author": {

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -77,6 +77,10 @@
     "prefix": "s-snippet",
     "body": ["{#snippet ${1:name(value)}}", "  ${0}", "{/snippet}"]
   },
+   "Svelte const": {
+    "prefix": "s-const",
+    "body": ["{@const ${0:name} = ${1:value}}"]
+  },
   "Svelte slot": {
     "prefix": "s-slot",
     "body": ["<slot></slot>"]


### PR DESCRIPTION
Adds a snippet for creating consts: https://svelte.dev/docs/svelte/@const