### PR TITLE
Feat: Added tabsequence to name state and derived runes

### DIFF
--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -1,7 +1,7 @@
 {
   "Svelte $state()": {
     "prefix": "s-state",
-    "body": ["let state = \\$state(${0})"]
+    "body": ["let ${1:state} = \\$state(${2})$0"]
   },
   "Svelte $state.frozen()": {
     "prefix": "s-state-frozen",
@@ -17,11 +17,11 @@
   },
   "Svelte $derived()": {
     "prefix": "s-derived",
-    "body": ["const value = \\$derived(${0});"]
+    "body": ["const ${1:value} = \\$derived(${2})$0"]
   },
-  "Svelte $derived.by() ": {
+  "Svelte $derived.by()": {
     "prefix": "s-derived-by",
-    "body": ["const value = \\$derived.by(()=>{", "  ${0}", "})"]
+    "body": ["const ${1:value} = \\$derived.by(() => {", "  ${2}", "})$0"]
   },
   "Svelte $effect()": {
     "prefix": "s-effect",


### PR DESCRIPTION
Hey,
I use your snippets on a daily basis and love most of them.
But I shy away from using the rune focused snippets because I have to rename my runes manually, that's why I created this PR.

I changed `s-state`, `s-derived` and `s-derived-by` and added another tab, so you can first name the variable and then enter their value. I also added the 'jump out' marker at the end so that you can jump out of the entire snippet when the rune is done.

Hope you like it.