### PR TITLE
feat: add basic snippets for remote functions (query, form, command)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
         "path": "./snippets/svelte-kit.json"
       },
       {
-        "language": "javascript",
-        "path": "./snippets/svelte-kit.json"
-      },
-      {
         "language": "svelte",
         "path": "./snippets/html.json"
       },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
         "path": "./snippets/svelte-kit.json"
       },
       {
+        "language": "javascript",
+        "path": "./snippets/svelte-kit.json"
+      },
+      {
         "language": "svelte",
         "path": "./snippets/html.json"
       },

--- a/snippets/svelte-kit.json
+++ b/snippets/svelte-kit.json
@@ -215,5 +215,19 @@
       "",
       "${0}"
     ]
+  },
+  "SvelteKit Remote Import": {
+    "prefix": "sk-rf-import",
+    "body": [
+      "import { $1 } from '\\$app/server';$0"
+    ]
+  },
+  "SvelteKit Remote Query": {
+    "prefix": "sk-rf-query",
+    "body": [
+      "export const ${1:getItems} = query(${2:schema}, async (${3:params}) => {",
+      "  $0",
+      "});"
+    ]
   }
 }

--- a/snippets/svelte-kit.json
+++ b/snippets/svelte-kit.json
@@ -225,7 +225,23 @@
   "SvelteKit Remote Query": {
     "prefix": "sk-rf-query",
     "body": [
-      "export const ${1:getItems} = query(${2:schema}, async (${3:params}) => {",
+      "export const ${1:getItems} = query(${2:schema}, async (${3:payload}) => {",
+      "  $0",
+      "});"
+    ]
+  },
+  "SvelteKit Remote Form": {
+    "prefix": "sk-rf-form",
+    "body": [
+      "export const ${1:formName} = form(${2:schema}, async (${3:payload}) => {",
+      "  $0",
+      "});"
+    ]
+  },
+  "SvelteKit Remote Command": {
+    "prefix": "sk-rf-command",
+    "body": [
+      "export const ${1:commandName} = command(${2:schema}, async (${3:payload}) => {",
       "  $0",
       "});"
     ]


### PR DESCRIPTION
Hey,

since I have been using your extension for quite some time now, I want to make a contribution. I am missing snippets for remote functions which I recently started using.

I added 4 snippets:

1. **sk-rf-import** (adds `import {} from '$app/server;'` for easy imports)
2. **sk-rf-query**
3. **sk-rf-form**
4. **sk-rf-command**